### PR TITLE
fix

### DIFF
--- a/src/bilichat_request/api/base.py
+++ b/src/bilichat_request/api/base.py
@@ -33,7 +33,10 @@ else:
     app = FastAPI(lifespan=lifespan)
 
 # 初始化 Limiter, 默认使用内存存储
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(
+    key_func=get_remote_address,
+    config_filename="a_filename_does_not_exist_fuck_you_windows",
+)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
```pytb
05-12 19:42:26 [ERROR] nonebot | Failed to import "nonebot_plugin_bilichat"
Traceback (most recent call last):
  File "C:\Users\Nonokara\Documents\Bot\nb\bot.py", line 56, in <module>
    prepare()
  File "C:\Users\Nonokara\Documents\Bot\nb\bot.py", line 46, in prepare
    nonebot.load_plugin(pl)
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\nonebot\plugin\load.py", line 42, in load_plugin
    return manager.load_plugin(module_path)
> File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\nonebot\plugin\manager.py", line 169, in load_plugin
    module = importlib.import_module(self._third_party_plugin_ids[name])
  File "C:\Users\Nonokara\AppData\Roaming\uv\python\cpython-3.12.10-windows-x86_64-none\Lib\importlib\__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\nonebot\plugin\manager.py", line 257, in exec_module
    super().exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\nonebot_plugin_bilichat\__init__.py", line 70, in <module>
    from . import api, base_content_parsing, command  # noqa: F401, E402
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\nonebot_plugin_bilichat\api\__init__.py", line 9, in <module>
    from .config import router as config_router
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\nonebot_plugin_bilichat\api\config.py", line 8, in <module>
    from nonebot_plugin_bilichat.request_api import init_request_apis
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\nonebot_plugin_bilichat\request_api\__init__.py", line 15, in <module>
    from .local import LOCAL_REQUEST_API_PATH, LOCAL_REQUEST_API_TOKEN
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\nonebot_plugin_bilichat\request_api\local.py", line 44, in <module>
    from bilichat_request.api.base import app  # type: ignore
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\bilichat_request\api\__init__.py", line 9, in <module>
    from .account import router as account_router
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\bilichat_request\api\account.py", line 10, in <module>
    from .base import error_handler
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\bilichat_request\api\base.py", line 36, in <module>
    limiter = Limiter(key_func=get_remote_address)
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\slowapi\extension.py", line 159, in __init__
    self.app_config = Config(
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\starlette\config.py", line 62, in __init__
    self.file_values = self._read_file(env_file)
  File "C:\Users\Nonokara\Documents\Bot\nb\.venv\Lib\site-packages\starlette\config.py", line 112, in _read_file
    for line in input_file.readlines():
UnicodeDecodeError: 'gbk' codec can't decode byte 0xb9 in position 18: illegal multibyte sequence
```

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 为 Limiter 提供一个虚拟的 config_filename，以跳过加载环境变量文件，并防止 Windows 上出现 gbk 解码错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Provide a dummy config_filename to Limiter to skip loading environment files and prevent gbk decoding errors on Windows

</details>