### PR TITLE
:alien: 修复pc样式动态截图

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bilichat-request"
-version = "0.5.5"
+version = "0.5.6"
 description = "Default template for PDM package"
 authors = [{ name = "Well404", email = "well_404@outlook.com" }]
 dependencies = [

--- a/src/bilichat_request/compat.py
+++ b/src/bilichat_request/compat.py
@@ -1,7 +1,7 @@
 from bilichat_request.config import NONEBOT_ENV
 
 if NONEBOT_ENV:
-    from nonebot_plugin_apscheduler import scheduler
+    from nonebot_plugin_apscheduler import scheduler  # type: ignore
 
 else:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler

--- a/src/bilichat_request/functions/render/dynamic.py
+++ b/src/bilichat_request/functions/render/dynamic.py
@@ -100,20 +100,15 @@ async def get_mobile_screenshot(page: Page, dynid: str):
 async def get_pc_screenshot(page: Page, dynid: str):
     """电脑端动态截图"""
     url = f"https://t.bilibili.com/{dynid}"
-    await page.set_viewport_size({"width": 2560, "height": 1080})
+    await page.set_viewport_size({"width": 950, "height": 720})
     await page.goto(url, wait_until="networkidle")
     # 动态被删除或者进审核了
     if page.url == "https://www.bilibili.com/404":
         raise NotFindAbortError(f"动态 {dynid} 不存在")
-    card = await page.query_selector(".card")
+    card = await page.query_selector(".bili-dyn-item__main")
     assert card
     clip = await card.bounding_box()
     assert clip
-    bar = await page.query_selector(".bili-dyn-action__icon")
-    assert bar
-    bar_bound = await bar.bounding_box()
-    assert bar_bound
-    clip["height"] = bar_bound["y"] - clip["y"]
     return page, clip
 
 


### PR DESCRIPTION
## Sourcery 总结

修复 PC 端动态帖子截图渲染问题，具体方法是调整视口大小和元素选择，并更新版本。

Bug 修复：
- 修正 PC 截图的视口尺寸，并更新动态卡片捕获的 DOM 选择器

杂项：
- 将包版本提升至 0.5.6
- 为 `nonebot_plugin_apscheduler` 导入添加类型忽略注释

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix dynamic post screenshot rendering on PC by adjusting viewport size and element selection, and update version.

Bug Fixes:
- Correct PC screenshot viewport dimensions and update DOM selector for the dynamic card capture

Chores:
- Bump package version to 0.5.6
- Add type ignore comment to nonebot_plugin_apscheduler import

</details>