### PR TITLE
Add nix for building Docker image

### DIFF
--- a/.github/workflows/nix-docker.yml
+++ b/.github/workflows/nix-docker.yml
@@ -1,0 +1,25 @@
+name: Build Docker image with Nix
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@main
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Build image
+        run: |
+          nix run "nixpkgs#nix-output-monitor" build ".#docker-image"
+          cp $(readlink ./result) .
+      - uses: actions/upload-artifact@main
+        with:
+          name: docker-image
+          path: '*.tar.gz'
+          compression-level: 0

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ temp/
 config.yaml
 pdm.lock
 uv.lock
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756819007,
+        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756395552,
+        "narHash": "sha256-5aJM14MpoLk2cdZAetu60OkLQrtFLWTICAyn1EP7ZpM=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "030dffc235dcf240d918c651c78dc5f158067b51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,116 @@
+{
+  description = "A basic flake using pyproject.toml project metadata";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, pyproject-nix, ... }:
+    let
+      inherit (nixpkgs) lib;
+      forAllSystems = lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+      pkgsBySystem = forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+        }
+      );
+
+      project = pyproject-nix.lib.project.loadPyproject {
+        projectRoot = ./.;
+      };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsBySystem.${system};
+
+          python = pkgs.python3;
+          attrs = project.renderers.buildPythonPackage { inherit python; };
+          scriptName = "bilirq";
+          package = python.pkgs.buildPythonPackage (attrs // { meta.mainProgram = scriptName; });
+        in
+        {
+          default = package;
+          docker-image =
+            let
+              browsers = pkgs.playwright-driver.browsers.override {
+                withChromium = false;
+                withFirefox = true;
+                withWebkit = false; # may require `export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu-24.04"`
+                withFfmpeg = false;
+                withChromiumHeadlessShell = false;
+              };
+              packageWrapper =
+                pkgs.runCommand "${attrs.pname}-wrapper"
+                  {
+                    nativeBuildInputs = [ pkgs.makeWrapper ];
+                    meta.mainProgram = scriptName;
+                  }
+                  ''
+                    mkdir -p $out/tmp
+                    makeWrapper "${lib.getExe package}" "$out/bin/${scriptName}" \
+                        --set-default PLAYWRIGHT_BROWSERS_PATH "${browsers}" \
+                        --set-default DOCKER "true" \
+                        --set-default API_HOST "0.0.0.0"
+                  '';
+            in
+            pkgs.dockerTools.buildLayeredImage {
+              name = attrs.pname;
+              tag = "latest";
+              layeringPipeline = [
+                [
+                  "subcomponent_out"
+                  [
+                    browsers
+                    python
+                  ]
+                ]
+                [
+                  "over"
+                  "rest"
+                  [
+                    "pipe"
+                    [
+                      [ "popularity_contest" ]
+                      [
+                        "limit_layers"
+                        72
+                      ]
+                    ]
+                  ]
+                ]
+              ];
+              contents = (
+                [ packageWrapper ]
+                ++ (with pkgs; [
+                  bashInteractive
+                  coreutils
+                  curl
+                  tini
+                ])
+              );
+              config = {
+                Entrypoint = [
+                  "/bin/tini"
+                  "--"
+                ];
+                Cmd = [ "/bin/${scriptName}" ];
+                ExposedPorts = {
+                  "40432" = { };
+                };
+                Env = [
+                  "TZ=Asia/Shanghai"
+                ];
+              };
+            };
+        }
+      );
+    };
+}


### PR DESCRIPTION
TODOs:
- [ ] Font files processing
- [ ] Healthckeck command
- [ ] Eliminate stdenv to reduce image size

<details>
<summary><del>Let me Gemini for you</del></summary>

好的，我们来为没有 Nix 背景的朋友们详细解释一下这个 Nix 文件。

这个文件是一个 Nix Flake，它是一种现代的、更具可重复性和可组合性的 Nix 配置方式。把它想象成一个更强大、更严谨的 `package.json` (JavaScript) 或 `pyproject.toml` (Python) 文件，但它不仅仅是为某个语言的项目服务，而是为整个项目环境，包括依赖、构建过程、甚至最终的 Docker 镜像，提供一个统一的声明式配置。

---

### 文件结构总览

这个 Nix 文件主要分为三个部分：

1.  `description`: 一句简单的描述，说明这个 Flake 的用途。
2.  `inputs`: 定义项目的所有外部依赖。就像你在 `package.json` 里写的 `dependencies` 一样，但这里指定的是其他 Nix Flakes。
3.  `outputs`: 定义这个 Flake 能产出什么。这是核心部分，比如可以产出软件包、开发环境、Docker 镜像等。

---

### 详细解析

#### `description` (描述)

```nix
description = "A basic flake using pyproject.toml project metadata";
```

这很简单，就是一句话告诉你这个 Flake 是干什么的：一个使用 `pyproject.toml` 元数据来构建的基础 Flake。

#### `inputs` (输入/依赖)

```nix
inputs = {
  nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
  pyproject-nix = {
    url = "github:pyproject-nix/pyproject.nix";
    inputs.nixpkgs.follows = "nixpkgs";
  };
};
```

这里定义了这个项目依赖两个外部的 Nix 配置集合（Flakes）：

*   `nixpkgs`: 这是 Nix 世界的“标准库”，包含了成千上万个软件包的构建配方。这里指定了使用 `nixpkgs` 的不稳定分支 (`nixpkgs-unstable`)，意味着会用上最新的软件包。
*   `pyproject-nix`: 这是一个社区提供的工具集，它能让 Nix 读懂并利用 Python 项目中的 `pyproject.toml` 文件来自动构建项目，省去了很多手动配置的麻烦。
    *   `inputs.nixpkgs.follows = "nixpkgs";` 这一行确保了 `pyproject-nix` 这个工具本身在构建时，使用的 `nixpkgs` 版本和我们项目主依赖的 `nixpkgs` 版本是完全一致的，这有助于避免版本冲突问题。

#### `outputs` (产出)

这是最复杂也最核心的部分。它接收 `inputs` 中定义的依赖作为参数，然后定义能构建出什么东西。

```nix
outputs =
  { nixpkgs, pyproject-nix, ... }:
  let
    # ... (一些变量定义)
  in
  {
    # ... (最终的产出物)
  };
```

`let ... in ...` 是 Nix 中的一种语法，用于在 `let` 部分定义局部变量，然后在 `in` 部分使用这些变量来构造最终的结果。

**1. 局部变量定义 (`let` 部分):**

```nix
inherit (nixpkgs) lib;
forAllSystems = lib.genAttrs nixpkgs.lib.systems.flakeExposed;
pkgsBySystem = forAllSystems (
  system:
  import nixpkgs {
    inherit system;
  }
);

project = pyproject-nix.lib.project.loadPyproject {
  projectRoot = ./.;
};
```

*   `forAllSystems`: Nix 的一大优势是跨平台。这段代码定义了一个辅助函数，可以为所有主流的操作系统和 CPU 架构（比如 `x86_64-linux`, `aarch64-linux`, `x86_64-darwin` 等）都执行一遍后续的构建逻辑。
*   `pkgsBySystem`: 基于上面的 `forAllSystems`，为每个支持的系统都生成一个 `pkgs` 集合。`pkgs` 是从 `nixpkgs` 中实例化出来的，包含了该系统下所有可用的软件包。例如 `pkgsBySystem.x86_64-linux` 就包含了所有适用于 x86 架构 Linux 的软件包。
*   `project`: 这是 `pyproject-nix` 工具发挥作用的地方。它读取当前目录 (`./.`) 下的 `pyproject.toml` 文件，并将其解析成一个 Nix 可以理解的项目对象。

**2. 最终产出物 (`in` 部分):**

```nix
{
  packages = forAllSystems (
    system:
    let
      # ...
    in
    {
      default = package;
      docker-image = /* ... */;
    }
  );
}
```

这里定义了一个名为 `packages` 的产出集合。同样，它会为每个支持的系统都生成对应的包。

*   **`default` 包:**
    ```nix
    let
      pkgs = pkgsBySystem.${system};
      python = pkgs.python3;
      attrs = project.renderers.buildPythonPackage { inherit python; };
      scriptName = "bilirq";
      package = python.pkgs.buildPythonPackage (attrs // { meta.mainProgram = scriptName; });
    in
    {
      default = package;
      // ...
    }
    ```
    这段代码做了以下几件事：
    1.  `pkgs = pkgsBySystem.${system};`: 根据当前正在构建的系统（比如 `x86_64-linux`），获取对应的软件包集合。
    2.  `python = pkgs.python3;`: 从软件包集合中选择 Python 3 解释器。
    3.  `attrs = project.renderers.buildPythonPackage { ... };`: 使用 `pyproject-nix` 工具，基于 `pyproject.toml` 的内容，自动生成构建这个 Python 项目所需的所有属性（比如项目名称、版本、依赖等）。
    4.  `package = python.pkgs.buildPythonPackage (attrs // { ... });`: 调用 Nix 内置的 Python 构建函数 `buildPythonPackage`，传入上面自动生成的属性，来实际构建这个 Python 包。`// { meta.mainProgram = scriptName; }` 这部分额外添加了一些元信息，指定了这个包的主程序入口是 `bilirq`。

    最终，这个构建好的 Python 包被命名为 `default`。这意味着当别人使用你的这个 Flake 时，可以直接通过 `nix build` 命令构建它。

*   **`docker-image` (Docker 镜像):**
    这是一个更复杂的产出物。它定义了如何构建一个包含上述 Python 应用的 Docker 镜像。

    ```nix
    docker-image =
      let
        browsers = pkgs.playwright-driver.browsers.override { /* ... */ };
        packageWrapper = pkgs.runCommand /* ... */;
      in
      pkgs.dockerTools.buildLayeredImage { /* ... */ };
    ```
    *   **准备依赖 (`let` 部分):**
        *   `browsers`: 你的应用似乎用到了 `playwright` 这个浏览器自动化工具。这里它配置了只安装 Firefox 浏览器驱动，而不需要 Chromium 和 Webkit，以减小镜像体积。
        *   `packageWrapper`: 这是一个非常关键的步骤。由于在 Nix 的环境中，软件的路径都是不固定的（例如 `/nix/store/....-python-3.10/...`），不能直接运行。`makeWrapper` 工具创建了一个启动脚本（`wrapper`），这个脚本会设置好所有必要的环境变量（比如 `PLAYWRIGHT_BROWSERS_PATH` 指向上面安装的 Firefox 驱动路径），然后再去调用真正的 Python 程序。这样就保证了无论在什么环境下，程序都能找到它的依赖。这里还额外设置了 `DOCKER` 和 `API_HOST` 两个环境变量。

    *   **构建镜像 (`in` 部分):**
        `pkgs.dockerTools.buildLayeredImage` 是 Nix 提供的用来构建 Docker 镜像的工具。它有很多配置项：
        *   `name`, `tag`: 镜像的名称和标签。
        *   `layeringPipeline`: 定义了如何将文件系统分层，这是一种优化镜像大小和构建速度的高级技巧。
        *   `contents`: 定义了需要包含到镜像里的所有内容。这里包含了我们上面创建的带启动脚本的包 (`packageWrapper`)，以及一些基础的命令行工具，如 `bash`, `coreutils`, `curl` 和 `tini`。`tini` 是一个轻量级的 `init` 程序，通常在容器中用来作为主进程，以正确处理信号和僵尸进程。
        *   `config`: 这部分直接对应 Docker 镜像的配置（`config.json`）。
            *   `Entrypoint`: 容器启动时执行的第一个命令，这里是 `tini`。
            *   `Cmd`: 传递给 `Entrypoint` 的命令，也就是我们应用的主程序 `/bin/bilirq`。
            *   `ExposedPorts`: 声明容器会暴露 40432 端口。
            *   `Env`: 设置容器内的环境变量，这里设置了时区为 `Asia/Shanghai`。

---

### 总结

对于一个非 Nix 用户来说，你可以这样理解这个文件：

**它是一个超级构建脚本，定义了如何从零开始，以一种完全可复现的方式，完成以下所有任务：**

1.  **依赖管理**: 精确锁定 `nixpkgs` (系统软件包) 和 `pyproject-nix` (Python 构建工具) 的版本。
2.  **Python 项目构建**: 自动读取 `pyproject.toml`，下载并构建所有 Python 依赖，然后将你自己的 Python 代码打包成一个可执行程序。
3.  **跨平台支持**: 以上的构建过程可以自动适配多种 CPU 架构和操作系统。
4.  **Docker 镜像打包**:
    *   下载并配置应用所需的浏览器驱动 (Playwright 的 Firefox)。
    *   创建一个能确保应用在容器内正确运行的启动脚本。
    *   将应用、Python 解释器、浏览器驱动和一些基础工具一起打包成一个优化的、分层的 Docker 镜像。
    *   配置好镜像的启动命令、暴露端口和环境变量。

**最终，开发者只需要在他的机器上安装 Nix，然后运行 `nix build .#packages.x86_64-linux.docker-image` 这样的命令，就可以得到一个与 CI/CD 服务器上或其他任何开发者机器上构建出来的**一模一样**的 Docker 镜像，彻底解决了“在我电脑上能跑”的问题。**

</details>