### PR TITLE
:lipstick: 修改视频渲染的过长av号为较短的bv号

### DIFF
--- a/src/bilichat_request/functions/render/video/__init__.py
+++ b/src/bilichat_request/functions/render/video/__init__.py
@@ -95,6 +95,7 @@ class VideoImage:
         uploaders: list[UP],
         b23_url: str,
         aid: str,
+        bvid: str,
         desc: str | None = None,
     ) -> None:
         self.cover: BytesIO = cover if isinstance(cover, BytesIO) else BytesIO(cover)
@@ -105,7 +106,7 @@ class VideoImage:
         """视频分区"""
         self.title: str = title
         """视频标题"""
-        self.desc: str = desc or "该视频没有简介"
+        self.desc: str = desc or "-"
         """视频简介"""
         self.view: str = view
         """播放量"""
@@ -129,6 +130,8 @@ class VideoImage:
         """b23短链"""
         self.aid: str = aid
         """av号"""
+        self.bvid: str = bvid
+        """bv号"""
 
     @classmethod
     async def get(
@@ -194,6 +197,7 @@ class VideoImage:
             uploaders=ups,
             b23_url=b23_url,
             aid=f"av{data['aid']}",
+            bvid=data["bvid"],
         )
 
     @staticmethod

--- a/src/bilichat_request/functions/render/video/style_blue.py
+++ b/src/bilichat_request/functions/render/video/style_blue.py
@@ -64,7 +64,7 @@ async def screenshot(
         dm_count=video_info.danmaku,
         reply_count=video_info.reply,
         upload_date=video_info.pubdate.strftime("%Y-%m-%d"),
-        av_number=video_info.aid,
+        video_id=video_info.bvid,
         video_summary=video_info.desc,
         like_count=video_info.like,
         coin_count=video_info.coin,

--- a/src/bilichat_request/static/style_blue/video-details.html
+++ b/src/bilichat_request/static/style_blue/video-details.html
@@ -263,7 +263,7 @@
           <span class="dm">{{ dm_count }}</span>
           <span class="reply">{{ reply_count }}</span>
           <span class="time">{{ upload_date }}</span>
-          <span class="av">{{ av_number }}</span>
+          <span class="video-id">{{ video_id }}</span>
         </div>
         <div class="summary">{{ video_summary }}</div>
         <div class="data-part2">


### PR DESCRIPTION
## Sourcery 总结

在整个视频渲染过程中，使用更短的 BV 标识符而非更长的 AV 号码，并简化默认视频描述占位符。

改进点：
- 在视频渲染模型中添加 `bvid` 属性，并通过其工厂方法进行传播
- 更新截图生成和 HTML 模板，以显示 BV ID (`video_id`) 而非 AV 号码
- 将默认视频描述从一个中文占位符更改为单个破折号

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use the shorter BV identifier instead of the longer AV number throughout video rendering, and simplify the default video description placeholder.

Enhancements:
- Add bvid property to the video render model and propagate it through its factory method
- Update screenshot generation and HTML template to display BV ID (video_id) instead of AV number
- Change default video description from a Chinese placeholder to a single dash

</details>