### PR TITLE
✨ 优化PC端动态截图 - 避免悬浮窗遮挡目标区域

### DIFF
--- a/src/bilichat_request/functions/render/dynamic.py
+++ b/src/bilichat_request/functions/render/dynamic.py
@@ -99,7 +99,7 @@ async def get_mobile_screenshot(page: Page, dynid: str):
 async def get_pc_screenshot(page: Page, dynid: str):
     """电脑端动态截图"""
     url = f"https://t.bilibili.com/{dynid}"
-    await page.set_viewport_size({"width": 950, "height": 720})
+    await page.set_viewport_size({"width": 2560, "height": 1440})
     await page.goto(url, wait_until="networkidle")
     # 动态被删除或者进审核了
     if page.url == "https://www.bilibili.com/404":
@@ -108,6 +108,8 @@ async def get_pc_screenshot(page: Page, dynid: str):
     assert card
     clip = await card.bounding_box()
     assert clip
+    clip["y"] -= 10
+    clip["height"] += 20
     return page, clip
 
 


### PR DESCRIPTION
## 问题描述
在PC端动态截图时，页面悬浮窗会遮挡目标截图区域，影响截图完整性。

## 解决方案
- **扩展视口宽度**：从950px增加到2560px，为悬浮窗提供侧边空间
- **优化裁剪区域**：微调Y坐标(-10px)和高度(+20px)，确保内容完整

## 技术细节
- `viewport_size`: `950x720` → `2560x1440`
- `clip["y"] -= 10` + `clip["height"] += 20`

## 效果
- 悬浮窗自然显示在页面侧边，不再遮挡目标区域
- 截图内容更完整，边界更精确

## 文件变更
- `src/bilichat_request/functions/render/dynamic.py`

## Sourcery 总结

优化PC动态截图，防止浮动窗口遮挡并确保完整内容捕获

增强功能：
- 将浏览器视口大小从 950x720 增加到 2560x1440
- 调整截图剪辑区域，将Y坐标向上移动10px并将高度延长20px

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize PC dynamic screenshots to prevent floating window overlays and ensure full content capture

Enhancements:
- Increase browser viewport size from 950x720 to 2560x1440
- Adjust screenshot clip region by shifting Y coordinate up 10px and extending height by 20px

</details>