### PR TITLE
🔧 注释掉视频详情中的类别显示

### DIFF
--- a/src/bilichat_request/static/style_blue/video-details.html
+++ b/src/bilichat_request/static/style_blue/video-details.html
@@ -225,7 +225,7 @@
     <div class="video">
       <div class="video-cover">
         <img class="cover" src="{{ cover_image }}" />
-        <span class="category">{{ video_category }}</span>
+        <!-- <span class="category">{{ video_category }}</span> -->
         <span class="time">{{ video_duration }}</span>
       </div>
       {% for up_info in up_infos %}


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 在视频详情视图中禁用视频分类徽章的渲染，同时保留其结构以供未来可能的使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Disable rendering of the video category badge in the video details view while keeping the structure available for potential future use.

</details>