### PR TITLE
:alien: compat htmlrender import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bilichat-request"
-version = "0.5.10"
+version = "0.5.11"
 description = "Default template for PDM package"
 authors = [{ name = "Well404", email = "well_404@outlook.com" }]
 dependencies = [

--- a/src/bilichat_request/adapters/browser/browser_ctx.py
+++ b/src/bilichat_request/adapters/browser/browser_ctx.py
@@ -30,7 +30,12 @@ async def launch_browser(**kwargs) -> Browser:
 
 
 if NONEBOT_ENV and bool({x for x in sys.modules if "nonebot_plugin_htmlrender" in x}):
-    from nonebot_plugin_htmlrender import get_browser  # type: ignore
+    try:
+        # nonebot-plugin-htmlrender >= 0.6.7
+        from nonebot_plugin_htmlrender.browser import get_browser  # type: ignore
+    except ImportError:
+        # Backward compatibility for old versions.
+        from nonebot_plugin_htmlrender import get_browser  # type: ignore
 
 else:
 


### PR DESCRIPTION
## 由 Sourcery 总结

:alien: 兼容 htmlrender 导入

增强：
- 为 `nonebot-plugin-htmlrender` 的新旧 `get_browser` 导入路径提供兼容性，以支持多个插件版本。

构建：
- 将包版本从 `0.5.10` 提升到 `0.5.11`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

:alien: compat htmlrender import

Enhancements:
- Add compatibility for both new and old nonebot-plugin-htmlrender get_browser import paths to support multiple plugin versions.

Build:
- Bump package version from 0.5.10 to 0.5.11.

</details>